### PR TITLE
Fix serializing discriminator

### DIFF
--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -356,6 +356,16 @@ class AttributeContainer(metaclass=AttributeContainerMeta):
             if value is not None:
                 if isinstance(attr, MapAttribute):
                     attr_value = attr.serialize(value, null_check=null_check)
+                # The value of a discriminator attribute is the literal value
+                # of the discriminator attribue in Dynamo.
+                # DiscriminatorAttribute.serialize attempts to get this literal
+                # value by looking it up the class map, but the keys in the
+                # class map are the classes themselves, and the values are the
+                # literal values of the attribute. In other words, we can skip
+                # serialization, because the attribute value is effectively
+                # already serialized.
+                elif isinstance(attr, DiscriminatorAttribute):
+                    attr_value = value
                 else:
                     attr_value = attr.serialize(value)
             else:


### PR DESCRIPTION
So what's going on here is that in `_container_serialize`, pynamo tries to iterate over all the attributes on an object and serialize each one. The code that does this looks like:
```
        for name, attr in self.get_attributes().items():
            value = getattr(self, name)
            <...>
            if value is not None:
                if isinstance(attr, MapAttribute):
                    attr_value = attr.serialize(value, null_check=null_check)
                else:
                    attr_value = attr.serialize(value)
```
at this point in the code, name is the name of the discriminator attribute (in our case `"discriminator"`), and `attr` is the `DiscriminatorAttribute` class. Then we get the value of the discriminator. Say we're getting a comment, this is the string  `"Comment"`. We then pass that into `attr.serialize`. `DiscriminatorAttribute.serialize` looks like this:
```
    def serialize(self, value):
        """
        Returns the discriminator value corresponding to the given class.
        """
        return self._class_map[value]
```
and the discriminator's class map maps the subclasses to the discriminator string value associated with those classes, so something like:
```
{
  <class 'models.document.Document'>: 'Document',
  <class 'models.comment.Comment'>: 'Comment',
  <class 'models.comment.CommentBlock'>: 'CommentBlock',
}
```
But since we're calling it with the string value of the discriminator here, we get a key error. Given that the thing it's trying to fetch from the map is just the string itself, this change just skips calling `serialize` on discriminator attributes, and sets `attr_value` to the value we already have.

I don't know if this fix works in all cases, but for our purposes it at least gets our use of discriminators working. What pynamo wants to do to fix this is up to them, but for us this seems to be enough