### PR TITLE
Revert discriminator changes

### DIFF
--- a/pynamodb/attributes.py
+++ b/pynamodb/attributes.py
@@ -356,16 +356,6 @@ class AttributeContainer(metaclass=AttributeContainerMeta):
             if value is not None:
                 if isinstance(attr, MapAttribute):
                     attr_value = attr.serialize(value, null_check=null_check)
-                # The value of a discriminator attribute is the literal value
-                # of the discriminator attribue in Dynamo.
-                # DiscriminatorAttribute.serialize attempts to get this literal
-                # value by looking it up the class map, but the keys in the
-                # class map are the classes themselves, and the values are the
-                # literal values of the attribute. In other words, we can skip
-                # serialization, because the attribute value is effectively
-                # already serialized.
-                elif isinstance(attr, DiscriminatorAttribute):
-                    attr_value = value
                 else:
                     attr_value = attr.serialize(value)
             else:

--- a/pynamodb/models.py
+++ b/pynamodb/models.py
@@ -651,13 +651,15 @@ class Model(AttributeContainer, metaclass=MetaModel):
         """
         cls._get_indexes()
         if index_name and cls._index_classes:
+            hash_key_attr_name = cls._index_classes[index_name]._hash_key_attribute().attr_name
             hash_key = cls._index_classes[index_name]._hash_key_attribute().serialize(hash_key)
         else:
+            hash_key_attr_name = cls._hash_keyname
             hash_key = cls._serialize_keys(hash_key)[0]
 
         # If this class has a discriminator attribute, filter the query to only return instances of this class.
         discriminator_attr = cls._get_discriminator_attribute()
-        if discriminator_attr:
+        if discriminator_attr and discriminator_attr.attr_name != hash_key_attr_name:
             filter_condition &= discriminator_attr.is_in(*discriminator_attr.get_registered_subclasses(cls))
 
         if page_size is None:


### PR DESCRIPTION
First, revert the changes from the last PR, which "fixed" serialization when using pynamo incorrectly, but broke serialization when using it correctly. Then add an extra check to the discriminator filter to only apply it when the discriminator attribute is not also the hash key. If you try to filter on a hash key the query won't run, because it's considered invalid

Generally, this shouldn't be the case. The implication of a discriminator being a hash key is that there are few enough values for the hash key that you can enumerate them with subclasses, which means that you're losing all the benefits of pynamo's partitioning, and pretty much guaranteeing hot partition problems. That being said, using dynamo in a non-optimal way shouldn't be an error on pynamo's end